### PR TITLE
Conditionally disable auto targeting.

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -118,6 +118,10 @@ end
 -- conditionals: The conditionals containing the current target
 -- returns: Whether or not we've changed the player's current target
 function Roids.FixEmptyTarget(conditionals)
+    if GetCVar("autoSelfCast") == "0" then
+        return false;
+    end
+
     if not conditionals.target then
         if UnitExists("target") then
             conditionals.target = "target";
@@ -232,7 +236,7 @@ function Roids.DoWithConditionals(msg, hook, fixEmptyTargetFunc, targetBeforeAct
         end
     end
     
-    if targetBeforeAction then
+    if conditionals.target ~= nil and targetBeforeAction then
         if not UnitIsUnit("target", conditionals.target) then
             needRetarget = true;
         end

--- a/Core.lua
+++ b/Core.lua
@@ -241,7 +241,11 @@ function Roids.DoWithConditionals(msg, hook, fixEmptyTargetFunc, targetBeforeAct
             needRetarget = true;
         end
         
+        local targetWillCast = SpellIsTargeting();
         TargetUnit(conditionals.target);
+        if targetWillCast then
+            return true;
+        end
     else
         if needRetarget then
             TargetLastTarget();

--- a/Core.lua
+++ b/Core.lua
@@ -118,14 +118,10 @@ end
 -- conditionals: The conditionals containing the current target
 -- returns: Whether or not we've changed the player's current target
 function Roids.FixEmptyTarget(conditionals)
-    if GetCVar("autoSelfCast") == "0" then
-        return false;
-    end
-
     if not conditionals.target then
         if UnitExists("target") then
             conditionals.target = "target";
-        else
+        elseif GetCVar("autoSelfCast") == "1" then
             conditionals.target = "player";
         end
     end

--- a/Core.lua
+++ b/Core.lua
@@ -241,11 +241,11 @@ function Roids.DoWithConditionals(msg, hook, fixEmptyTargetFunc, targetBeforeAct
             needRetarget = true;
         end
         
-        local targetWillCast = SpellIsTargeting();
-        TargetUnit(conditionals.target);
-        if targetWillCast then
-            return true;
+        if SpellIsTargeting() then
+            SpellStopCasting()
         end
+
+        TargetUnit(conditionals.target);
     else
         if needRetarget then
             TargetLastTarget();


### PR DESCRIPTION
The changes in this pull request disable automatic targeting when the user disables auto self casting under interface options. With the current release version, Roid-Macros will always self cast on the player when no target is selected.

So the following macro:
/cast [@mouseover,help] Renew

Will always cast renew on the player if they have no target. After these changes, Roid-Macros will only do this if the interface option for auto self cast is enabled. So basically if auto self cast is selected, nothing changes, if it's not selected, then it works as the user expects.

I also discovered an issue if the user uses a macro that casts a spell (say @mouseover) while another spell is awaiting a target. With the release version, the spell you have pending will be cast on the target, and that target will remain the target when the macro completes. This is odd as you previously had no target selected, and it casts the wrong spell! The last commit fixes this by canceling the pending cast before selecting a target. At first I thought this was related to the auto self casting change, but I went back to master and the issue still occurs. I would have split the PR otherwise and can do so still if you'd like.
