### PR TITLE
Fixed mouseover support for NotGrid.

### DIFF
--- a/Extensions/Mouseover/NotGrid.lua
+++ b/Extensions/Mouseover/NotGrid.lua
@@ -4,6 +4,8 @@
 ]]
 local _G = _G or getfenv(0)
 local Roids = _G.Roids or {}
+
+local CreateFrames = nil;
 Roids.mouseoverUnit = Roids.mouseoverUnit or nil;
 
 local Extension = Roids.RegisterExtension("NotGrid");
@@ -17,30 +19,35 @@ function Extension.OnLeave()
     Roids.mouseoverUnit = nil;
 end
 
-function Extension.ConfigUnitFrame(_, frame)
-    local pattern = "%d+";
-    local name = frame:GetName();
+function Roids:NotGrid_CreateFrames()
+    CreateFrames(NotGrid); -- call the original
     
-    enter = frame:GetScript("OnEnter");
-    leave = frame:GetScript("OnLeave");
-    
-    frame:SetScript("OnEnter", function()
-        enter();
-        Extension.OnEnter();
-    end);
-    
-    frame:SetScript("OnLeave", function()
-        leave();
-        Extension.OnLeave();
-    end);
+    -- NotGrid stores all of it's frames in the NotGrid.UnitFrames table.
+    for k, frame in pairs(NotGrid.UnitFrames) do
+        local enter = frame:GetScript("OnEnter");
+        local leave = frame:GetScript("OnLeave");
+
+        frame:SetScript("OnEnter", function()
+            enter();
+            Extension.OnEnter();
+        end);
+
+        frame:SetScript("OnLeave", function()
+            leave();
+            Extension.OnLeave();
+        end);
+    end
 end
 
 function Extension.OnLoad()
-    if arg1 ~= "NotGrid" then
-        return;
+    -- NotGrid loads before Roids, so if NotGrid is enabled, then it's global will exist.
+    if not NotGrid then
+	-- Hooking manually as we need a post hook.
+        CreateFrames = NotGrid.CreateFrames;
+        NotGrid.CreateFrames = Roids.NotGrid_CreateFrames;
     end
     
-    Extension.HookMethod(_G["NotGrid"], "ConfigUnitFrame", "ConfigUnitFrame");
+    Extension.UnregisterEvent("ADDON_LOADED", "Onload")
 end
 
 _G["Roids"] = Roids;


### PR DESCRIPTION
Hey,

With the current NotGrid mouseover extension in Roids, using a mouseover heal macro does not work if you have a target selected. Instead of casting on the target under your mouse cursor, it will instead cast the heal on the person you have targeted. After debugging this a bit, I realized it only applies to NotGrid. Aka if I mouseover a player in the physical world, while targeting another, it works as expected (casts the heal on the mouseover target).

Digging further, I found that the NotGrid mouseover extension is actually not working at all. There are two causes for this:

1. NotGrid loads before Roids, so the current check for arg1 = "NotGrid" will never pass, as NotGrid has already loaded. This means the extension is never enabled.
2. If you force Roids to load first (by renaming it to !Roid-Macros), it still doesn't work, which I'm guessing is due to changes within NotGrid. I didn't dig too far into this, but I'm guessing they changed when or how ConfigUnitFrames() is called.

I went ahead and rewrote the loading/hooking so that it works with the latest version of NotGrid. The changes are basically:
1. Assume that NotGrid will load before Roids, so remove the arg1 check and replace it with a check for the NotGrid global variable.
2. Hook NotGrid:CreateFrames() rather then NotGrid:ConfigUnitFrames() and iterate over the frames as they're stored in a table (NotGrid.UnitFrames). I had to manually hook the function (like done in the ag extension) as it must execute after the original.
3. Added the unregister ADDON_LOADED event, like in the ag extension.

I had first attempted to hook NotGrid:CreateUnitFrame, however this lead to some strange font not set errors that I couldn't figure out, so I went with the loop all frames approach. Otherwise it basically works the same, by hooking the OnEnter/OnLeave scripts.