### PR TITLE
Fondlez extension blizzard

### DIFF
--- a/Extensions/Mouseover/Blizzard.lua
+++ b/Extensions/Mouseover/Blizzard.lua
@@ -1,39 +1,77 @@
 --[[
 	Author: Fondlez
   
-  This extension adds support for mouseover macros in Roid-Macros for the
-  the default Blizzard target-of-target frame.
+  This extension adds improved support for mouseover macros in Roid-Macros 
+  for the default Blizzard frames.
 ]]
 local _G = _G or getfenv(0)
 local Roids = _G.Roids or {}
-Roids.mouseoverUnit = Roids.mouseoverUnit or nil;
+Roids.mouseoverUnit = Roids.mouseoverUnit or nil
 
-local Extension = Roids.RegisterExtension("Blizzard");
+local Extension = Roids.RegisterExtension("Blizzard")
 
 function Extension.RegisterMouseoverForFrame(frame, unit)
     if not frame then return end
     
-    local onenter = frame:GetScript("OnEnter");
-    local onleave = frame:GetScript("OnLeave");
+    local onenter = frame:GetScript("OnEnter")
+    local onleave = frame:GetScript("OnLeave")
     
     frame:SetScript("OnEnter", function()
-        Roids.mouseoverUnit = unit;
+        Roids.mouseoverUnit = unit
         if onenter then
-            onenter();
+            onenter()
         end
-    end);
+    end)
     
     frame:SetScript("OnLeave", function()
-        Roids.mouseoverUnit = nil;
+        Roids.mouseoverUnit = nil
         if onleave then
-            onleave();
+            onleave()
         end
-    end);
+    end)
 end
 
-function Extension.OnLoad()
-    Extension.RegisterMouseoverForFrame(TargetofTargetHealthBar, 
-      "targettarget");
-    Extension.RegisterMouseoverForFrame(TargetofTargetManaBar, "targettarget");
-    Extension.RegisterMouseoverForFrame(TargetofTargetFrame, "targettarget");
+do
+    local frames = {
+        ["PlayerFrame"] = "player",
+        ["PetFrame"] = "pet",
+        ["TargetFrame"] = "target",
+        ["PartyMemberFrame1"] = "party1",
+        ["PartyMemberFrame2"] = "party2",
+        ["PartyMemberFrame3"] = "party3",
+        ["PartyMemberFrame4"] = "party4",
+        ["PartyMemberFrame1PetFrame"] = "party1",
+        ["PartyMemberFrame2PetFrame"] = "party2",
+        ["PartyMemberFrame3PetFrame"] = "party3",
+        ["PartyMemberFrame4PetFrame"] = "party4",
+    }
+    
+    local bars = { 
+        "HealthBar", 
+        "ManaBar",
+    }
+    
+    local allFrames = {}
+    for name, unit in pairs(frames) do
+         allFrames[name] = unit
+        for i, bar in ipairs(bars) do
+            allFrames[name .. bar] = unit
+        end
+    end
+    
+    -- Inconsisent naming for TargetofTarget required
+    allFrames["TargetofTargetFrame"] = "targettarget"
+    allFrames["TargetofTargetHealthBar"] = "targettarget"
+    allFrames["TargetofTargetManaBar"] = "targettarget"
+
+    function Extension.OnLoad()
+        local frame
+        for name, unit in pairs(allFrames) do
+          frame = _G[name]
+          
+          if frame then
+              Extension.RegisterMouseoverForFrame(frame, unit)
+          end
+       end
+    end
 end

--- a/Extensions/Mouseover/Blizzard.lua
+++ b/Extensions/Mouseover/Blizzard.lua
@@ -1,0 +1,39 @@
+--[[
+	Author: Fondlez (http://github.com/fondlez)
+  
+  This extension adds support for mouseover macros in Roid-Macros for the
+  the default Blizzard target-of-target frame.
+]]
+local _G = _G or getfenv(0)
+local Roids = _G.Roids or {}
+Roids.mouseoverUnit = Roids.mouseoverUnit or nil;
+
+local Extension = Roids.RegisterExtension("Blizzard");
+
+function Extension.RegisterMouseoverForFrame(frame, unit)
+    if not frame then return end
+    
+    local onenter = frame:GetScript("OnEnter");
+    local onleave = frame:GetScript("OnLeave");
+    
+    frame:SetScript("OnEnter", function()
+        Roids.mouseoverUnit = unit;
+        if onenter then
+            onenter();
+        end
+    end);
+    
+    frame:SetScript("OnLeave", function()
+        Roids.mouseoverUnit = nil;
+        if onleave then
+            onleave();
+        end
+    end);
+end
+
+function Extension.OnLoad()
+    Extension.RegisterMouseoverForFrame(TargetofTargetHealthBar, 
+      "targettarget");
+    Extension.RegisterMouseoverForFrame(TargetofTargetManaBar, "targettarget");
+    Extension.RegisterMouseoverForFrame(TargetofTargetFrame, "targettarget");
+end

--- a/Extensions/Mouseover/Blizzard.lua
+++ b/Extensions/Mouseover/Blizzard.lua
@@ -1,5 +1,5 @@
 --[[
-	Author: Fondlez (http://github.com/fondlez)
+	Author: Fondlez
   
   This extension adds support for mouseover macros in Roid-Macros for the
   the default Blizzard target-of-target frame.

--- a/Roid-Macros.toc
+++ b/Roid-Macros.toc
@@ -17,6 +17,7 @@ Compatibility\SuperMacro.lua
 Compatibility\pfUI.lua
 
 Extensions\Mouseover\GameTooltip.lua
+Extensions\Mouseover\Blizzard.lua
 Extensions\Mouseover\CT_RaidAssist.lua
 Extensions\Mouseover\CT_UnitFrames.lua
 Extensions\Mouseover\DiscordUnitFrames.lua


### PR DESCRIPTION
I was testing healing with only the Roid-Macros addon enabled and discovered that - after enabling the Escape -> Interface -> Options "Show Target of Target" - I was unable to mouseover heal against the default Bllizzard TargetofTarget frame, since `UnitExists("mouseover")` does not recognize the frame.

This code fixes that problem. I generalized it as a "Blizzard" unitframe mouseover extension, in case of future changes against Blizzard frames.

Code successfully tested in-game.